### PR TITLE
feat: add STEP clause to count-controlled FOR loops

### DIFF
--- a/src/Inter/interpreter.rs
+++ b/src/Inter/interpreter.rs
@@ -275,7 +275,7 @@ impl Interpreter {
                 }
                 Ok(())
             }
-            Stmt::For { identifier, start, end, body } => self.evaluate_for(identifier, start, end, body),
+            Stmt::For { identifier, start, end, body, step } => self.evaluate_for(identifier, start, end, body, step),
             Stmt::OpenFile { filename, mode  } => self.evaluate_open_file(filename, mode),
             Stmt::CloseFile { filename } => self.evaluate_close_file(filename),
             Stmt::WriteFile { filename, value } => self.evaluate_write_file(filename, value),
@@ -578,12 +578,14 @@ impl Interpreter {
         }
     }
 
-    fn evaluate_for(&mut self, identifier: &String, start: &Expr, end: &Expr, body: &BlockStmt) -> Result<(), CPSError> {
+    fn evaluate_for(&mut self, identifier: &String, start: &Expr, end: &Expr, body: &BlockStmt, step: &Expr) -> Result<(), CPSError> {
         let start_value = self.evaluate_expr(start)?;
         let end_value = self.evaluate_expr(end)?;
+        let step_value = self.evaluate_expr(step)?;
 
         let start_int;
         let end_int;
+        let step_int;
 
         match start_value {
             Value::Integer(n) => start_int = n,
@@ -637,13 +639,52 @@ impl Interpreter {
                 });
             }
         }
+        match step_value {
+            Value::Integer(n) => step_int = n,
+            Value::Real(n) => {
+                if n.fract() != 0.0 {
+                    return Err(CPSError {
+                        error_type: ErrorType::Runtime,
+                        message: format!("FOR loop step value must evaluate to an integer number, got: {:?}", step_value),
+                        hint: None,
+                        line: 0,
+                        column: 0,
+                        source: None,
+                    });
+                }
+                step_int = n as i64;
+            },
+            _ => {
+                return Err(CPSError {
+                    error_type: ErrorType::Runtime,
+                    message: format!("FOR loop step value must evaluate to an integer number, got: {:?}", step_value),
+                    hint: None,
+                    line: 0,
+                    column: 0,
+                    source: None,
+                });
+            }
+        }
 
         // first declare the loop variable
         self.current_env
             .borrow_mut()
             .define(identifier.to_owned(), Value::Integer(start_int.to_owned()))?;
 
-        for i in start_int.to_owned()..=end_int.to_owned() {
+        // if step int is 0, panick
+        if step_int == 0 {
+            return Err(CPSError {
+                error_type: ErrorType::Runtime,
+                message: "The STEP in a for loop cannot be equal to 0.".to_string(),
+                hint: None,
+                line: 0,
+                column: 0,
+                source: None,
+            })
+        }
+
+        let mut i = start_int;
+        while (step_int > 0 && i <= end_int) || (step_int < 0 && i >= end_int) {
             self.current_env
                 .borrow_mut()
                 .set(identifier, Value::Integer(i))
@@ -659,6 +700,8 @@ impl Interpreter {
             for stmt in &body.statements {
                 self.evaluate_stmt(stmt)?;
             }
+
+            i += step_int;
         }
 
         Ok(())

--- a/src/Inter/interpreter.rs
+++ b/src/Inter/interpreter.rs
@@ -619,7 +619,7 @@ impl Interpreter {
                 if n.fract() != 0.0 {
                     return Err(CPSError {
                         error_type: ErrorType::Runtime,
-                        message: format!("FOR loop start value must be an integer, got real number: {}", n),
+                        message: format!("FOR loop end value must be an integer, got real number: {}", n),
                         hint: None,
                         line: 0,
                         column: 0,

--- a/src/Parser/ast.rs
+++ b/src/Parser/ast.rs
@@ -68,7 +68,7 @@ pub enum Stmt {
     Case { identifier: Box<Expr>, cases: Vec<(CaseCondition, BlockStmt)>, otherwise: Option<BlockStmt> },
     While { condition: Box<Expr>, body: BlockStmt },
     Repeat { body: BlockStmt, until: Box<Expr> },
-    For { identifier: String, start: Box<Expr>, end: Box<Expr>, body: BlockStmt },
+    For { identifier: String, start: Box<Expr>, end: Box<Expr>, body: BlockStmt, step: Box<Expr> },
     Assignment { identifier: String, array_index: Option<(Box<Expr>, Option<Box<Expr>>)>, value: Box<Ast> },
     Constant { identifier: String, value: Value },
     Decleration { identifier: String, type_: Type},
@@ -257,8 +257,8 @@ impl Stmt {
                 result.push_str(&format!("{}ENDWHILE", indent_str));
                 result
             }
-            Stmt::For { identifier, start, end, body } => {
-                let mut result = format!("{}FOR {} = {} TO {}\n", indent_str, identifier, start.to_prefix(), end.to_prefix());
+            Stmt::For { identifier, start, end, body, step } => {
+                let mut result = format!("{}FOR {} = {} TO {} STEP {}\n", indent_str, identifier, start.to_prefix(), end.to_prefix(), step.to_prefix());
                 for stmt in &body.statements {
                     result.push_str(&stmt.to_prefix(indent + 1));
                     result.push('\n');

--- a/src/Parser/parser.rs
+++ b/src/Parser/parser.rs
@@ -978,6 +978,27 @@ impl Parser {
             }
         };
 
+        // check for STEP
+        let curr_token = self.peek(0);
+        let mut step_expr = Expr::Literal(Value::Integer(1)); // set the default step to 1
+        if curr_token.token_type == TokenType::Step {
+            self.advance();
+            step_expr = match self.parse_expr(0)? {
+                Ast::Expression(e) => e,
+                Ast::Identifier(id) => Expr::Literal(Value::Identifier(id)),
+                _ => {
+                    return Err(CPSError{
+                        error_type: ErrorType::Syntax,
+                        message: "Invalid step value in FOR loop".to_string(),
+                        hint: Some("Step value must be a valid expression".to_string()),
+                        line: for_token.line,
+                        column: for_token.column,
+                        source: Some(self.source.clone()),
+                    })
+                }
+            };
+        }
+
         self.scope += 1; // enter the scope of the for loop
 
         let body_statements = self.parse_statements()?;
@@ -1029,6 +1050,7 @@ impl Parser {
             start: Box::new(start_expr), 
             end: Box::new(end_expr),
             body: BlockStmt { statements: body_statements }, 
+            step: Box::new(step_expr),
         }))
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `STEP` values to `FOR` loops.
  * Supports positive and negative increments for ascending and descending loops.
  * Defaults to a step of 1 when omitted.

* **Bug Fixes**
  * Rejects zero or non-integer step values.
  * Reports syntax errors for malformed `STEP` expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->